### PR TITLE
feat: Implement Rust CRUD API with Actix and Diesel

### DIFF
--- a/rust_crud_api/.env
+++ b/rust_crud_api/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=mysql://root:password@127.0.0.1:3306/rust_crud_db

--- a/rust_crud_api/Cargo.toml
+++ b/rust_crud_api/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rust_crud_api"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+actix-web = "4.5.1"
+serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.115"
+dotenvy = "0.15.7"
+env_logger = "0.11.3"
+
+# Diesel for synchronous operations (like CLI) and schema generation
+diesel = { version = "2.1.6", features = ["mysql", "serde_json", "with-bigdecimal"] }
+
+# Diesel-async for non-blocking database operations in Actix
+diesel-async = { version = "0.4.1", features = ["bb8", "mysql"] }
+
+# For handling DECIMAL types
+bigdecimal = { version = "0.4.3", features = ["serde"] }

--- a/rust_crud_api/diesel.toml
+++ b/rust_crud_api/diesel.toml
@@ -1,0 +1,9 @@
+# For documentation on how to configure this file,
+# see https://diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"
+custom_type_derives = ["diesel::query_builder::QueryId", "Clone"]
+
+[migrations_directory]
+dir = "migrations"

--- a/rust_crud_api/migrations/2025-09-10-082057_create_products_table/down.sql
+++ b/rust_crud_api/migrations/2025-09-10-082057_create_products_table/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE products;

--- a/rust_crud_api/migrations/2025-09-10-082057_create_products_table/up.sql
+++ b/rust_crud_api/migrations/2025-09-10-082057_create_products_table/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+CREATE TABLE products (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    price DECIMAL(10, 2) NOT NULL
+);

--- a/rust_crud_api/src/handlers.rs
+++ b/rust_crud_api/src/handlers.rs
@@ -1,0 +1,146 @@
+use actix_web::{web, HttpResponse, Responder};
+use diesel::prelude::*;
+use diesel_async::{RunQueryDsl, AsyncMysqlConnection, AsyncConnection};
+use diesel_async::pooled_connection::bb8::Pool;
+use diesel::dsl::last_insert_id;
+
+use crate::models::{Product, NewProduct};
+use crate::schema::products;
+
+// Type alias for the connection pool
+type DbPool = Pool<AsyncMysqlConnection>;
+
+// Handler to create a new product
+pub async fn create_product(
+    pool: web::Data<DbPool>,
+    new_product: web::Json<NewProduct>,
+) -> impl Responder {
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(_) => return HttpResponse::InternalServerError().finish(),
+    };
+
+    let product_data = new_product.into_inner();
+
+    // Transaction to ensure atomicity: insert, get last ID, then fetch the new record.
+    let result = conn.transaction(|conn| Box::pin(async move {
+        // Execute the insert
+        diesel::insert_into(products::table)
+            .values(&product_data)
+            .execute(conn)
+            .await?;
+
+        // Get the last inserted ID (MySQL specific)
+        let last_id_result = diesel::select(last_insert_id).get_result::<u64>(conn).await?;
+
+        // Fetch the newly created product
+        products::table
+            .find(last_id_result as i32)
+            .get_result::<Product>(conn)
+            .await
+    })).await;
+
+    match result {
+        Ok(product) => HttpResponse::Created().json(product),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+// Handler to get all products
+pub async fn get_products(pool: web::Data<DbPool>) -> impl Responder {
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(_) => return HttpResponse::InternalServerError().finish(),
+    };
+
+    let result = products::table
+        .load::<Product>(&mut conn)
+        .await;
+
+    match result {
+        Ok(products) => HttpResponse::Ok().json(products),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+// Handler to get a product by its ID
+pub async fn get_product_by_id(
+    pool: web::Data<DbPool>,
+    product_id: web::Path<i32>,
+) -> impl Responder {
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(_) => return HttpResponse::InternalServerError().finish(),
+    };
+
+    let result = products::table
+        .find(product_id.into_inner())
+        .get_result::<Product>(&mut conn)
+        .await;
+
+    match result {
+        Ok(product) => HttpResponse::Ok().json(product),
+        Err(diesel::NotFound) => HttpResponse::NotFound().finish(),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+// Handler to update a product by its ID
+pub async fn update_product_by_id(
+    pool: web::Data<DbPool>,
+    product_id: web::Path<i32>,
+    product_update: web::Json<NewProduct>,
+) -> impl Responder {
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(_) => return HttpResponse::InternalServerError().finish(),
+    };
+
+    let id = product_id.into_inner();
+    let product_data = product_update.into_inner();
+
+    // Transaction to ensure atomicity: update, then fetch the updated record.
+    let result = conn.transaction(|conn| Box::pin(async move {
+        diesel::update(products::table.find(id))
+            .set((
+                products::name.eq(&product_data.name),
+                products::description.eq(&product_data.description),
+                products::price.eq(&product_data.price),
+            ))
+            .execute(conn)
+            .await?;
+
+        // Fetch the updated product
+        products::table
+            .find(id)
+            .get_result::<Product>(conn)
+            .await
+    })).await;
+
+    match result {
+        Ok(product) => HttpResponse::Ok().json(product),
+        Err(diesel::NotFound) => HttpResponse::NotFound().finish(),
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}
+
+// Handler to delete a product by its ID
+pub async fn delete_product_by_id(
+    pool: web::Data<DbPool>,
+    product_id: web::Path<i32>,
+) -> impl Responder {
+    let mut conn = match pool.get().await {
+        Ok(conn) => conn,
+        Err(_) => return HttpResponse::InternalServerError().finish(),
+    };
+
+    let result = diesel::delete(products::table.find(product_id.into_inner()))
+        .execute(&mut conn)
+        .await;
+
+    match result {
+        Ok(0) => HttpResponse::NotFound().finish(), // No rows deleted
+        Ok(_) => HttpResponse::NoContent().finish(), // 204 No Content
+        Err(_) => HttpResponse::InternalServerError().finish(),
+    }
+}

--- a/rust_crud_api/src/main.rs
+++ b/rust_crud_api/src/main.rs
@@ -1,0 +1,56 @@
+use actix_web::{web, App, HttpServer, middleware::Logger};
+use diesel_async::pooled_connection::{bb8::Pool, AsyncDieselConnectionManager};
+use diesel_async::AsyncMysqlConnection;
+use dotenvy::dotenv;
+use std::env;
+
+mod models;
+mod schema;
+mod handlers;
+
+// Type alias for the connection pool for easier use
+type DbPool = Pool<AsyncMysqlConnection>;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    // Load environment variables from .env file
+    dotenv().ok();
+
+    // Initialize logger
+    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    // Get database URL from environment
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+
+    // Create a new connection manager
+    let config = AsyncDieselConnectionManager::<AsyncMysqlConnection>::new(database_url);
+
+    // Create a new connection pool
+    let pool = Pool::builder()
+        .build(config)
+        .await
+        .expect("Failed to create database connection pool.");
+
+    println!("🚀 Server started successfully at http://127.0.0.1:8080");
+
+    // Start the Actix web server
+    HttpServer::new(move || {
+        App::new()
+            // Add the connection pool to the application data
+            .app_data(web::Data::new(pool.clone()))
+            // Add a logger middleware
+            .wrap(Logger::default())
+            // Define application routes
+            .service(
+                web::scope("/products")
+                    .route("", web::post().to(handlers::create_product))
+                    .route("", web::get().to(handlers::get_products))
+                    .route("/{id}", web::get().to(handlers::get_product_by_id))
+                    .route("/{id}", web::put().to(handlers::update_product_by_id))
+                    .route("/{id}", web::delete().to(handlers::delete_product_by_id)),
+            )
+    })
+    .bind(("127.0.0.1", 8080))?
+    .run()
+    .await
+}

--- a/rust_crud_api/src/models.rs
+++ b/rust_crud_api/src/models.rs
@@ -1,0 +1,23 @@
+use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
+use crate::schema::products;
+use bigdecimal::BigDecimal;
+
+// Struct for reading data from the database
+#[derive(Queryable, Selectable, Serialize, Debug, PartialEq)]
+#[diesel(table_name = products)]
+pub struct Product {
+    pub id: i32,
+    pub name: String,
+    pub description: Option<String>,
+    pub price: BigDecimal,
+}
+
+// Struct for creating a new product (no id)
+#[derive(Insertable, Deserialize, Debug)]
+#[diesel(table_name = products)]
+pub struct NewProduct {
+    pub name: String,
+    pub description: Option<String>,
+    pub price: BigDecimal,
+}

--- a/rust_crud_api/src/schema.rs
+++ b/rust_crud_api/src/schema.rs
@@ -1,0 +1,13 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use diesel::mysql::sql_types::Decimal;
+
+    products (id) {
+        id -> Integer,
+        name -> Varchar,
+        description -> Nullable<Text>,
+        price -> Decimal,
+    }
+}


### PR DESCRIPTION
This commit introduces a complete RESTful API for performing CRUD operations on a `products` table.

The application is built with Rust using the Actix-web framework for the server and Diesel with diesel-async for non-blocking MySQL database interaction.

Key features include:
- Modular project structure (handlers, models, main).
- Asynchronous database connection pooling.
- Database migrations managed by Diesel CLI.
- Configuration managed via a .env file.
- All five CRUD endpoints (Create, Read All, Read by ID, Update, Delete) are implemented with proper error handling and transactional safety for write operations.